### PR TITLE
fix: only show brands that the user has purses for

### DIFF
--- a/ui/src/components/vault/NewVault.jsx
+++ b/ui/src/components/vault/NewVault.jsx
@@ -85,6 +85,7 @@ export default function NewVault() {
         <VaultCollateral
           dispatch={dispatch}
           collaterals={collaterals}
+          purses={purses}
           brandToInfo={brandToInfo}
         />
       );

--- a/ui/src/components/vault/VaultCollateral.jsx
+++ b/ui/src/components/vault/VaultCollateral.jsx
@@ -34,7 +34,12 @@ const makeHeaderCell = data => (
   <TableCell key={data.id}>{data.label}</TableCell>
 );
 
-function VaultCollateral({ dispatch, collaterals, brandToInfo }) {
+function VaultCollateral({
+  dispatch,
+  purses,
+  collaterals: collateralsRaw,
+  brandToInfo,
+}) {
   const {
     displayRatio,
     displayPercent,
@@ -44,6 +49,11 @@ function VaultCollateral({ dispatch, collaterals, brandToInfo }) {
   const makeOnClick = row => _ev => {
     dispatch(setVaultCollateral(row));
   };
+
+  // Filter out brands that the wallet does not have purses for
+  const purseBrands = new Set(purses && purses.map(p => p.brand));
+  const collaterals =
+    collateralsRaw && collateralsRaw.filter(c => purseBrands.has(c.brand));
 
   if (!collateralAvailable(collaterals)) {
     return noCollateralAvailableDiv;


### PR DESCRIPTION
Closes: #9 

In the vault collateral selection, filter out any brands that
the user doesn't have a wallet for.