### PR TITLE
chore: actually try to build in the build step

### DIFF
--- a/.github/workflows/deploy-treasury.yml
+++ b/.github/workflows/deploy-treasury.yml
@@ -84,6 +84,8 @@ jobs:
       run: |
         echo "NETLIFY_SITE_ID=$(cat "${{ matrix.deployment }}/NETLIFY_SITE_ID")" >> $GITHUB_ENV
         tar -C "${{ matrix.deployment }}" -cf - src | tar -C dapp/ui -xvf -
+    - name: Use on-chain configuration
+      run: ./ui/use-on-chain-config.js
     - name: yarn build:react in dapp ui
       run: yarn build:react
       working-directory: ./dapp/ui

--- a/.github/workflows/deploy-treasury.yml
+++ b/.github/workflows/deploy-treasury.yml
@@ -45,6 +45,7 @@ jobs:
       working-directory: ./dapp
     - name: Use on-chain configuration
       run: ./ui/use-on-chain-config.js
+      working-directory: ./dapp
     - name: yarn build in dapp
       run: yarn build
       working-directory: ./dapp

--- a/.github/workflows/deploy-treasury.yml
+++ b/.github/workflows/deploy-treasury.yml
@@ -27,8 +27,6 @@ jobs:
     - name: yarn install in agoric-sdk
       run: yarn install
       working-directory: ./agoric-sdk
-    - name: Use on-chain configuration
-      run: ./ui/use-on-chain-config.js
     - name: yarn build in agoric-sdk
       run: yarn build
       working-directory: ./agoric-sdk
@@ -45,6 +43,8 @@ jobs:
     - name: Agoric install in dapp
       run: agoric install
       working-directory: ./dapp
+    - name: Use on-chain configuration
+      run: ./ui/use-on-chain-config.js
     - name: yarn build in dapp
       run: yarn build
       working-directory: ./dapp

--- a/.github/workflows/deploy-treasury.yml
+++ b/.github/workflows/deploy-treasury.yml
@@ -27,6 +27,8 @@ jobs:
     - name: yarn install in agoric-sdk
       run: yarn install
       working-directory: ./agoric-sdk
+    - name: Use on-chain configuration
+      run: ./ui/use-on-chain-config.js
     - name: yarn build in agoric-sdk
       run: yarn build
       working-directory: ./agoric-sdk
@@ -84,8 +86,6 @@ jobs:
       run: |
         echo "NETLIFY_SITE_ID=$(cat "${{ matrix.deployment }}/NETLIFY_SITE_ID")" >> $GITHUB_ENV
         tar -C "${{ matrix.deployment }}" -cf - src | tar -C dapp/ui -xvf -
-    - name: Use on-chain configuration
-      run: ./ui/use-on-chain-config.js
     - name: yarn build:react in dapp ui
       run: yarn build:react
       working-directory: ./dapp/ui

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -67,6 +67,8 @@ jobs:
 
     - name: agoric install
       run: agoric install
+    - name: configure
+      run: ./ui/use-on-chain-config.js
     - name: yarn build
       run: yarn build
     - name: yarn test (everything)

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "start": "react-scripts start",
     "test": "exit 0",
-    "build": "exit 0",
+    "build": "react-scripts build",
     "build:ses": "cp ../node_modules/ses/dist/lockdown.umd.js public/",
     "build:react": "yarn build:pre-patch; react-scripts build; yarn build:post-patch",
     "build:pre-patch": "node -r esm ./ses-patch.js src/install-ses-lockdown.js",


### PR DESCRIPTION
Dapp-treasury had `exit 0` as the `yarn build` script in the `ui` directory. This PR actually tries to perform a production build. 