### PR TITLE
chore: include running use-on-chain-config.js in the build step.

### DIFF
--- a/.github/workflows/deploy-treasury.yml
+++ b/.github/workflows/deploy-treasury.yml
@@ -43,9 +43,6 @@ jobs:
     - name: Agoric install in dapp
       run: agoric install
       working-directory: ./dapp
-    - name: Use on-chain configuration
-      run: ./ui/use-on-chain-config.js
-      working-directory: ./dapp
     - name: yarn build in dapp
       run: yarn build
       working-directory: ./dapp

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -67,8 +67,6 @@ jobs:
 
     - name: agoric install
       run: agoric install
-    - name: configure
-      run: ./ui/use-on-chain-config.js
     - name: yarn build
       run: yarn build
     - name: yarn test (everything)

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,9 +13,10 @@
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "start": "react-scripts start",
     "test": "exit 0",
-    "build": "react-scripts build",
+    "configure": "node use-on-chain-config",
+    "build": "yarn build:react",
     "build:ses": "cp ../node_modules/ses/dist/lockdown.umd.js public/",
-    "build:react": "yarn build:pre-patch; react-scripts build; yarn build:post-patch",
+    "build:react": "yarn configure; yarn build:pre-patch; react-scripts build; yarn build:post-patch",
     "build:pre-patch": "node -r esm ./ses-patch.js src/install-ses-lockdown.js",
     "build:post-patch": "node -r esm ./ses-patch.js build/index.html",
     "eject": "react-scripts eject"


### PR DESCRIPTION
chore: include running use-on-chain-config.js in the build step. Only have one build step for simplicity.

Sorry for the additional PR, but I realized that trying to configure before every build as a separate step was a fool's errand and I should just include the configuration in the build script itself. I also made all `build` commands point to the same action for simplicity. 

This should solve the [failure we see on `agoric-sdk` CI](https://github.com/Agoric/agoric-sdk/pull/3091/checks?check_run_id=2579868930). 