### PR TITLE
chore: use node 14, not 12

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        # TODO: ['14.x', '16.x']
+        node-version: [14.x]
     steps:
     - name: Checkout treasury
       uses: actions/checkout@v2


### PR DESCRIPTION
Nightly CI was failing because node 12 was being tested