### PR TITLE
fix: add load collaterals error message and retry button

### DIFF
--- a/ui/src/components/vault/VaultCollateral.jsx
+++ b/ui/src/components/vault/VaultCollateral.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import {
+  Button,
   FormControl,
   FormLabel,
   Radio,
@@ -13,9 +14,11 @@ import {
   TableRow,
 } from '@material-ui/core';
 
+import { Alert } from '@material-ui/lab';
+
 import '../../types/types';
 
-import { setVaultCollateral } from '../../store';
+import { setVaultCollateral, setLoadCollateralsError } from '../../store';
 import { makeDisplayFunctions } from '../helpers';
 import { useApplicationContext } from '../../contexts/Application';
 
@@ -53,8 +56,27 @@ function VaultCollateral({
   runLoCTerms,
   brandToInfo,
 }) {
-  const { state } = useApplicationContext();
-  const { useRloc } = state;
+  const { state, retrySetup } = useApplicationContext();
+  const { useRloc, loadCollateralsError } = state;
+
+  const onRetryClicked = () => {
+    dispatch(setLoadCollateralsError(null));
+    retrySetup();
+  };
+
+  const loadColalteralsErrorDiv = (
+    <Alert
+      action={
+        <Button onClick={onRetryClicked} color="inherit" size="small">
+          Retry
+        </Button>
+      }
+      severity="error"
+    >
+      A problem occured while loading the collaterals — make sure you have RUN
+      in your Zoe fees purse.
+    </Alert>
+  );
 
   const {
     displayRatio,
@@ -72,7 +94,9 @@ function VaultCollateral({
   const collaterals =
     collateralsRaw && collateralsRaw.filter(c => purseBrands.has(c.brand));
 
-  if (!collaterals) {
+  if (loadCollateralsError) {
+    return loadColalteralsErrorDiv;
+  } else if (!collaterals) {
     return standByForCollateralDiv;
   } else if (!collateralAvailable(collaterals)) {
     return noCollateralAvailableDiv;

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -22,6 +22,7 @@ export const initial = {
   runLoCTerms: /** @type { CollateralInfo | null } */ (null),
   vaultToManageId: /** @type {string | null} */ (null),
   useRloc: false,
+  loadCollateralsError: /** @type {string | null} */ null,
 };
 
 /**
@@ -49,6 +50,7 @@ export const initial = {
  *    resetVault: () => TreasuryReducer,
  *    setAutoswap: (payload: typeof initial.autoswap) => TreasuryReducer,
  *    setUseRloc: (payload: boolean) => TreasuryReducer,
+ *    setLoadCollateralsError: (payload: string | null) => TreasuryReducer,
  * }} TreasuryActions
  */
 
@@ -73,6 +75,7 @@ export const {
     resetVault,
     setAutoswap,
     setUseRloc,
+    setLoadCollateralsError,
   },
   // @ts-ignore tsc can't tell that autodux is callable
 } = autodux({


### PR DESCRIPTION
Demo:
![error-load](https://user-images.githubusercontent.com/8848650/146137344-261ec977-f41b-4b07-a885-f72057313aba.gif)

It flashes the "no collaterals" message just between showing the loading state and the table. I think this is because autodux is setting collaterals to an empty array before setting it to a real array from its initial null state, but that's a separate issue to tackle.