### PR TITLE
fix: use bg color that mui recognizes

### DIFF
--- a/ui/src/components/ApproveOfferSB.jsx
+++ b/ui/src/components/ApproveOfferSB.jsx
@@ -1,30 +1,16 @@
 import React from 'react';
 import Snackbar from '@material-ui/core/Snackbar';
-import IconButton from '@material-ui/core/IconButton';
-import CloseIcon from '@material-ui/icons/Close';
+import Alert from '@material-ui/lab/Alert';
 
 const ApproveOfferSB = ({
   open,
   handleClose,
   message = 'Please approve the offer in your wallet',
 }) => (
-  <Snackbar
-    open={open}
-    autoHideDuration={6000}
-    onClose={handleClose}
-    message={message}
-    action={
-      <React.Fragment>
-        <IconButton
-          size="small"
-          aria-label="close"
-          color="inherit"
-          onClick={handleClose}
-        >
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </React.Fragment>
-    }
-  />
+  <Snackbar open={open} autoHideDuration={6000}>
+    <Alert onClose={handleClose} severity="success">
+      {message}
+    </Alert>
+  </Snackbar>
 );
 export default ApproveOfferSB;

--- a/ui/src/pages/App.jsx
+++ b/ui/src/pages/App.jsx
@@ -22,7 +22,7 @@ const theme = createMuiTheme({
       main: '#00b1a6', // green
     },
     background: {
-      default: 'transparent',
+      default: '#ffffff00',
     },
   },
   overrides: {


### PR DESCRIPTION
fixes: https://github.com/Agoric/dapp-treasury/issues/68

The "transparent" color is needed so the background gradient is not covered by a white rectangle where the content is. Apparently the snackbar throws an error when trying to render, because it uses this color and doesn't support `transparent`. Making it use a hex value instead of the keyword `transparent` fixes it, but then the actual snackbar becomes transparent, so I changed it to use a "success" alert instead:

![image](https://user-images.githubusercontent.com/8848650/149236764-5ed1d11b-aa13-4f82-b4a0-4476a104dd1e.png)
