### PR TITLE
fix: adjust vault negative amounts

### DIFF
--- a/ui/src/components/Swap.jsx
+++ b/ui/src/components/Swap.jsx
@@ -1,11 +1,11 @@
 import { React, useState, useEffect } from 'react';
 import { E } from '@endo/captp';
 import {
-  divideBy,
+  floorDivideBy,
   invertRatio,
   makeRatio,
   makeRatioFromAmounts,
-  multiplyBy,
+  floorMultiplyBy,
 } from '@agoric/zoe/src/contractSupport';
 import { Nat } from '@endo/nat';
 import { stringifyAmountValue } from '@agoric/ui-components';
@@ -69,7 +69,7 @@ const useStyles = makeStyles(theme => ({
 
 const makeInverseFromAmounts = (x, y) => makeRatioFromAmounts(y, x);
 const composeRatio = (x, y) =>
-  makeRatioFromAmounts(multiplyBy(x.numerator, y), x.denominator);
+  makeRatioFromAmounts(floorMultiplyBy(x.numerator, y), x.denominator);
 
 /* eslint-disable complexity */
 export default function Swap() {
@@ -278,7 +278,7 @@ export default function Swap() {
       const giveInfo = getInfoForBrand(brandToInfo, inputRate.brand);
       const wantInfo = getInfoForBrand(brandToInfo, outputRate.brand);
       const oneDisplayUnit = 10n ** Nat(wantInfo.decimalPlaces);
-      const wantPrice = divideBy(
+      const wantPrice = floorDivideBy(
         AmountMath.make(outputRate.brand, oneDisplayUnit),
         marketRate,
       );
@@ -305,11 +305,11 @@ export default function Swap() {
       // and so depends on whether the user entered the In or
       // the Out amount most recently
       if (quote.rate && sameStructure(source, quote.amount)) {
-        const value = multiplyBy(source, quote.rate).value;
+        const value = floorMultiplyBy(source, quote.rate).value;
         return { amount: value, label: `Quoted ${label}` };
       }
       if (marketRatio) {
-        const value = multiplyBy(source, marketRatio).value;
+        const value = floorMultiplyBy(source, marketRatio).value;
         return { amount: value, label: `Estimated ${label}` };
       }
     }

--- a/ui/src/components/vault/VaultManagement/NatPurseAmountInput.jsx
+++ b/ui/src/components/vault/VaultManagement/NatPurseAmountInput.jsx
@@ -43,6 +43,7 @@ const PurseAmountInput = ({
   onAmountChange,
   brandToFilter,
   brandToInfo,
+  error = null,
   purseSelectorDisabled = false,
   amountInputDisabled = false,
 }) => {
@@ -75,6 +76,8 @@ const PurseAmountInput = ({
           decimalPlaces={decimalPlaces}
           placesToShow={placesToShow}
           disabled={amountInputDisabled}
+          error={error !== null}
+          helperText={error ?? ' '}
         />
       </Grid>
     </Grid>

--- a/ui/src/components/vault/test/AdjustVaultForm.test.jsx
+++ b/ui/src/components/vault/test/AdjustVaultForm.test.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { act } from '@testing-library/react';
+import { mount } from 'enzyme';
+import { AmountMath } from '@agoric/ertp';
+import AdjustVaultForm from '../VaultManagement/AdjustVaultForm';
+import NatPurseAmountInput from '../VaultManagement/NatPurseAmountInput';
+import CollateralActionChoice from '../VaultManagement/CollateralActionChoice';
+import DebtActionChoice from '../VaultManagement/DebtActionChoice';
+
+jest.mock('@agoric/ertp', () => ({
+  AmountMath: {
+    make: jest.fn(),
+    add: jest.fn(),
+    subtract: jest.fn(),
+  },
+}));
+
+jest.mock('../VaultManagement/NatPurseAmountInput', () => () =>
+  'NatPurseAmountInput',
+);
+
+jest.mock('../VaultManagement/makeAdjustVaultOffer', () => ({
+  makeAdjustVaultOffer: jest.fn(),
+}));
+
+test('shows an error when withdrawing more than locked', () => {
+  const locked = { brand: 'BLD', value: 100n };
+  const debt = { brand: 'RUN', value: 50n };
+  AmountMath.subtract.mockImplementation(() => {
+    throw new Error();
+  });
+
+  const component = mount(<AdjustVaultForm locked={locked} debt={debt} />);
+  const collateralActionChoice = component.find(CollateralActionChoice);
+  act(() => collateralActionChoice.props().setCollateralAction('withdraw'));
+
+  let lockedInput = component.find(NatPurseAmountInput).at(0);
+  expect(lockedInput.props().error).toEqual(null);
+
+  act(() => lockedInput.props().onAmountChange(0n));
+  component.update();
+  lockedInput = component.find(NatPurseAmountInput).at(0);
+  expect(lockedInput.props().error).toEqual('Insufficient locked balance');
+});
+
+test('shows an error when repaying more than borrowed', () => {
+  const locked = { brand: 'BLD', value: 100n };
+  const debt = { brand: 'RUN', value: 50n };
+  AmountMath.subtract.mockImplementation(() => {
+    throw new Error();
+  });
+
+  const component = mount(<AdjustVaultForm locked={locked} debt={debt} />);
+  const debtActionChoice = component.find(DebtActionChoice);
+  act(() => debtActionChoice.props().setDebtAction('repay'));
+
+  let debtInput = component.find(NatPurseAmountInput).at(1);
+  expect(debtInput.props().error).toEqual(null);
+
+  act(() => debtInput.props().onAmountChange(0n));
+  component.update();
+  debtInput = component.find(NatPurseAmountInput).at(1);
+  expect(debtInput.props().error).toEqual('Insufficient debt balance');
+});


### PR DESCRIPTION
fixes: [#248](https://github.com/Agoric/dapp-token-economy/issues/248)

Instead of crashing/throwing an app-level error, show an invalid input with a message indicating the locked/debt amount to subtract exceeds the current locked/debt amount

Also tweaked the cancel button so that it didn't look like a primary action

Screenshot:
![image](https://user-images.githubusercontent.com/8848650/153259362-4f97ba24-693a-497c-8d9b-ac1214825942.png)
