### PR TITLE
fix: fix vault management view state

### DIFF
--- a/ui/src/components/ApproveOfferSB.jsx
+++ b/ui/src/components/ApproveOfferSB.jsx
@@ -7,7 +7,7 @@ const ApproveOfferSB = ({
   handleClose,
   message = 'Please approve the offer in your wallet',
 }) => (
-  <Snackbar open={open} autoHideDuration={6000}>
+  <Snackbar open={open} onClose={handleClose} autoHideDuration={6000}>
     <Alert onClose={handleClose} severity="success">
       {message}
     </Alert>

--- a/ui/src/components/vault/VaultManagement/ChangesTable.jsx
+++ b/ui/src/components/vault/VaultManagement/ChangesTable.jsx
@@ -107,6 +107,17 @@ const ChangesTable = ({
 
   const debtDeltaString = getDeltaString(debt, debtAfterDelta);
 
+  const collateralizationDeltaString =
+    newCollateralizationRatio &&
+    !(
+      newCollateralizationRatio?.numerator?.value ===
+        collateralizationRatio?.numerator?.value &&
+      newCollateralizationRatio?.denominator?.value ===
+        collateralizationRatio?.denominator?.value
+    )
+      ? `${displayPercent(newCollateralizationRatio)}%`
+      : '...';
+
   const rows = [
     createData(
       'Collateral Locked',
@@ -116,9 +127,7 @@ const ChangesTable = ({
     createData(
       'Collateralization Ratio',
       `${displayPercent(collateralizationRatio)}%`,
-      newCollateralizationRatio
-        ? `${displayPercent(newCollateralizationRatio)}%`
-        : '...',
+      collateralizationDeltaString,
     ),
     createData(
       'Outstanding Debt',

--- a/ui/src/components/vault/VaultManagement/CloseVaultForm.jsx
+++ b/ui/src/components/vault/VaultManagement/CloseVaultForm.jsx
@@ -81,6 +81,11 @@ const CloseVaultForm = ({
   const classes = useStyles();
 
   useEffect(() => {
+    setCollateralValue(locked.value);
+    setRunValue(debt.value);
+  }, [locked, debt]);
+
+  useEffect(() => {
     if (needToAddOfferToWallet) {
       makeCloseVaultOffer({
         vaultToManageId,

--- a/ui/src/components/vault/VaultManagement/CollateralActionChoice.jsx
+++ b/ui/src/components/vault/VaultManagement/CollateralActionChoice.jsx
@@ -19,7 +19,9 @@ const useStyles = makeStyles(theme => ({
 const collateralActionChoice = ({ collateralAction, setCollateralAction }) => {
   const classes = useStyles();
   const handleCollateralAction = (_event, newCollateralAction) => {
-    setCollateralAction(newCollateralAction);
+    if (newCollateralAction !== null) {
+      setCollateralAction(newCollateralAction);
+    }
   };
   return (
     <ToggleButtonGroup

--- a/ui/src/components/vault/VaultManagement/DebtActionChoice.jsx
+++ b/ui/src/components/vault/VaultManagement/DebtActionChoice.jsx
@@ -19,7 +19,9 @@ const useStyles = makeStyles(theme => ({
 const debtActionChoice = ({ debtAction, setDebtAction }) => {
   const classes = useStyles();
   const handleDebtAction = (_event, newDebtAction) => {
-    setDebtAction(newDebtAction);
+    if (newDebtAction !== null) {
+      setDebtAction(newDebtAction);
+    }
   };
   return (
     <ToggleButtonGroup

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@agoric/assert" "0.3.16-dev-0c5d62c.0+0c5d62c"
     n-readlines "^1.0.0"
 
-"@agoric/assert@0.3.16-dev-0c5d62c.0+0c5d62c", "@agoric/assert@dev":
+"@agoric/assert@0.3.16-dev-0c5d62c.0+0c5d62c":
   version "0.3.16-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.16-dev-0c5d62c.0.tgz#3673e0ecc2eacd4d5bb84f6ed315af384793a862"
   integrity sha512-SYpANSBpupJZnydwDDLeXN9q+cHJboJ5L4sM71uTa+146SG2Dv7hraUTOjE4B3Ocxx/vH6qTBtT9xos6P2mvFA==
@@ -7947,7 +7947,7 @@ esm@3.2.25:
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
-"esm@github:agoric-labs/esm#Agoric-built":
+esm@agoric-labs/esm#Agoric-built:
   version "3.2.25"
   resolved "https://codeload.github.com/agoric-labs/esm/tar.gz/3603726ad4636b2f865f463188fcaade6375638e"
 


### PR DESCRIPTION
fixes #16 - Now updates current/proposed column correctly when vault state changes
fixes #84 - Now redirects to the vaults page when refreshed or if the vault is missing

Other fixes:
- Enables/disables the "make offer" button based on if a valid offer can be made.
- Fixed bug where the snackbar would never autohide
- Make the "close vault" form update its inputs when the vault balances update
- Disable the locked/debt inputs when "no action" is selected