### PR TITLE
fix: dont depend on now-removed collateralizationRatio

### DIFF
--- a/ui/src/components/Treasury.jsx
+++ b/ui/src/components/Treasury.jsx
@@ -110,7 +110,7 @@ const useStyles = makeStyles(theme => {
 function VaultList() {
   const classes = useStyles();
   const {
-    state: { approved, vaults, brandToInfo, loadTreasuryError },
+    state: { approved, vaults, brandToInfo, loadTreasuryError, treasury },
     dispatch,
     retrySetup,
   } = useApplicationContext();
@@ -186,7 +186,7 @@ function VaultList() {
     return loadTreasuryErrorAlert;
   }
 
-  if (vaults === null) {
+  if (vaults === null || !treasury) {
     return (
       <div className={classes.root}>
         <CircularProgress style={{ marginTop: 48 }} />

--- a/ui/src/components/VaultSummary.jsx
+++ b/ui/src/components/VaultSummary.jsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { AmountMath } from '@agoric/ertp';
-import {
-  floorMultiplyBy,
-  makeRatioFromAmounts,
-} from '@agoric/zoe/src/contractSupport';
+import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport';
 import { Nat } from '@endo/nat';
 import { E } from '@endo/eventual-send';
 import { makeStyles } from '@material-ui/core/styles';
@@ -68,11 +65,14 @@ const useStyles = makeStyles(theme => {
   };
 });
 
-const calcRatio = (priceRate, newLock, newBorrow) => {
-  const lockPrice = floorMultiplyBy(newLock, priceRate);
-  const newRatio = makeRatioFromAmounts(lockPrice, newBorrow);
-  return newRatio;
-};
+const calcRatio = (priceRate, newLock, newBorrow) =>
+  makeRatioFromAmounts(
+    AmountMath.make(newLock.brand, newLock.value * priceRate.numerator.value),
+    AmountMath.make(
+      newBorrow.brand,
+      newBorrow.value * priceRate.denominator.value,
+    ),
+  );
 
 export function VaultSummary({ vault, brandToInfo, id }) {
   const classes = useStyles();

--- a/ui/src/components/test/Treasury.test.jsx
+++ b/ui/src/components/test/Treasury.test.jsx
@@ -32,6 +32,7 @@ beforeEach(() => {
   state.approved = false;
   state.vaults = null;
   state.brandToInfo = [];
+  state.treasury = null;
 });
 
 test('renders a message when the dapp needs approval', () => {
@@ -66,6 +67,7 @@ test('renders a loading indicator when vaults are null', () => {
 test('renders a message when no vaults are available', () => {
   state.approved = true;
   state.vaults = {};
+  state.treasury = {};
 
   const component = mount(<VaultList />);
 
@@ -79,6 +81,7 @@ test('renders the vaults', () => {
     },
   };
   state.approved = true;
+  state.treasury = { priceAuthority: { quoteGiven: jest.fn() } };
 
   const component = mount(<VaultList />);
 
@@ -95,6 +98,7 @@ test('hides closed vaults by default', () => {
     },
   };
   state.approved = true;
+  state.treasury = { priceAuthority: { quoteGiven: jest.fn() } };
 
   const component = mount(<VaultList />);
 
@@ -109,6 +113,7 @@ test('shows closed vaults when enabled', () => {
     },
   };
   state.approved = true;
+  state.treasury = { priceAuthority: { quoteGiven: jest.fn() } };
 
   const component = mount(<VaultList />);
   const showClosedCheckbox = component.find(Checkbox);
@@ -128,6 +133,7 @@ test('shows loading vaults', () => {
     },
   };
   state.approved = true;
+  state.treasury = { priceAuthority: { quoteGiven: jest.fn() } };
 
   const component = mount(<VaultList />);
 

--- a/ui/src/components/vault/VaultManagement/VaultManagement.jsx
+++ b/ui/src/components/vault/VaultManagement/VaultManagement.jsx
@@ -60,7 +60,7 @@ const VaultManagement = () => {
     vaults,
     vaultToManageId,
     brandToInfo,
-    autoswap: { ammAPI },
+    treasury: { priceAuthority },
   } = state;
 
   /** @type { VaultData } */
@@ -104,7 +104,6 @@ const VaultManagement = () => {
   ] = makeRatioState();
   const [marketPrice, setMarketPrice] = makeRatioState();
   const [collateralizationRatio, setCollateralizationRatio] = makeRatioState();
-  // calculate based on market price
 
   const {
     displayBrandPetname,
@@ -162,13 +161,11 @@ const VaultManagement = () => {
       locked.brand,
       10n ** Nat(decimalPlaces),
     );
-    assert(ammAPI, 'ammAPI missing');
-    const quoteP = E(ammAPI).getInputPrice(
-      inputAmount,
-      AmountMath.makeEmpty(debt.brand),
-    );
+    assert(priceAuthority, 'priceAuthority missing');
+    const quoteP = E(priceAuthority).quoteGiven(inputAmount, debt.brand);
 
-    quoteP.then(({ amountIn, amountOut }) => {
+    quoteP.then(({ quoteAmount }) => {
+      const [{ amountIn, amountOut }] = quoteAmount.value;
       const newMarketPrice = makeRatioFromAmounts(
         amountOut, // RUN
         amountIn, // 1 unit of collateral

--- a/ui/src/components/vault/VaultManagement/VaultManagement.jsx
+++ b/ui/src/components/vault/VaultManagement/VaultManagement.jsx
@@ -6,10 +6,7 @@ import { Redirect } from 'react-router-dom';
 import { Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-import {
-  floorMultiplyBy,
-  makeRatioFromAmounts,
-} from '@agoric/zoe/src/contractSupport';
+import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport';
 import { AmountMath } from '@agoric/ertp';
 import { Nat } from '@endo/nat';
 import { E } from '@endo/eventual-send';
@@ -138,18 +135,14 @@ const VaultManagement = () => {
     setOpenApproveOfferSB(true);
   };
 
-  /**
-   * Collateralization ratio is the value of collateral to debt.
-   *
-   * @param {Ratio} priceRate
-   * @param {Amount} newLock
-   * @param {Amount} newBorrow
-   */
-  const calcRatio = (priceRate, newLock, newBorrow) => {
-    const lockPrice = floorMultiplyBy(newLock, priceRate);
-    const newRatio = makeRatioFromAmounts(lockPrice, newBorrow);
-    return newRatio;
-  };
+  const calcRatio = (priceRate, newLock, newBorrow) =>
+    makeRatioFromAmounts(
+      AmountMath.make(newLock.brand, newLock.value * priceRate.numerator.value),
+      AmountMath.make(
+        newBorrow.brand,
+        newBorrow.value * priceRate.denominator.value,
+      ),
+    );
 
   // run once when component loaded.
   // TODO: use makeQuoteNotifier

--- a/ui/src/contexts/Application.jsx
+++ b/ui/src/contexts/Application.jsx
@@ -149,16 +149,20 @@ const setupTreasury = async (dispatch, brandToInfo, zoe, board, instanceID) => {
   const instance = await E(board).getValue(instanceID);
   /** @type { ERef<VaultFactory> } */
   const treasuryAPIP = E(zoe).getPublicFacet(instance);
-  const [treasuryAPI, terms, collaterals] = await Promise.all([
+  const termsP = E(zoe).getTerms(instance);
+  const [treasuryAPI, terms, collaterals, priceAuthority] = await Promise.all([
     treasuryAPIP,
-    E(zoe).getTerms(instance),
+    termsP,
     E(treasuryAPIP).getCollaterals(),
+    E.get(termsP).priceAuthority,
   ]);
   const {
     issuers: { RUN: runIssuer },
     brands: { RUN: runBrand },
   } = terms;
-  dispatch(setTreasury({ instance, treasuryAPI, runIssuer, runBrand }));
+  dispatch(
+    setTreasury({ instance, treasuryAPI, runIssuer, runBrand, priceAuthority }),
+  );
   await storeAllBrandsFromTerms({
     dispatch,
     terms,

--- a/ui/src/types/types.js
+++ b/ui/src/types/types.js
@@ -94,5 +94,6 @@
  *   treasuryAPI: unknown,
  *   runIssuer: Issuer,
  *   runBrand: Brand,
+ *   priceAuthority: unknown,
  * }} VaultState
  */


### PR DESCRIPTION
fixes https://github.com/Agoric/dapp-treasury/issues/87

This doesn't change any current behavior of how frequently the market price / collateralization ratio is updated, just fixes the UI since `vault.collateralizationRatio` was removed.

Considerations for better price updates:
- [getPriceNotifier ](https://agoric.com/documentation/repl/priceauthority.html#getpricenotifier-brandin-brandout)- doesn't exist?
- [makeQuoteNotifier](https://agoric.com/documentation/repl/priceauthority.html#makequotenotifier-amountin-brandout) - does this do a write transaction to the chain?
- Chaining [quoteWhenGT](https://agoric.com/documentation/repl/priceauthority.html#quotewhengt-amountin-amountoutlimit)/[quoteWhenLT](https://agoric.com/documentation/repl/priceauthority.html#quotewhenlt-amountin-amountoutlimit) - works for big price moves but not small, kinda messy and potential memory leak
- Call `priceAuthority.quoteGiven` every ~30 seconds and/or after input changes - simple but effective?