### PR TITLE
fix: use new vault notifiers

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "@agoric/ui-components": "dev",
     "@agoric/wallet-connection": "dev",
     "@agoric/zoe": "dev",
+    "@agoric/run-protocol": "dev",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/ui/src/components/Treasury.jsx
+++ b/ui/src/components/Treasury.jsx
@@ -120,10 +120,10 @@ function VaultList() {
   );
 
   const vaultsList = Object.entries(vaults ?? {});
-  const vaultsToRender = vaultsList.filter(
-    entry =>
-      entry[1].status !== 'Declined' &&
-      !(!showClosed && ['Closed', 'Error in offer'].includes(entry[1].status)),
+  const vaultsToRender = vaultsList.filter(entry =>
+    showClosed
+      ? ['Closed', 'Error in offer'].includes(entry[1].status)
+      : !['Closed', 'Error in offer', 'Declined'].includes(entry[1].status),
   );
 
   const [redirect, setRedirect] = useState(false);
@@ -144,8 +144,8 @@ function VaultList() {
     setShowClosed(value);
   };
 
-  const showShowClosedToggle = vaultsList?.find(
-    entry => entry[1].status === 'Closed',
+  const showShowClosedToggle = vaultsList?.find(entry =>
+    ['Closed', 'Error in offer'].includes(entry[1].status),
   );
 
   const loadTreasuryErrorAlert = (

--- a/ui/src/components/Treasury.jsx
+++ b/ui/src/components/Treasury.jsx
@@ -22,6 +22,7 @@ import { VaultSummary } from './VaultSummary';
 import ErrorBoundary from './ErrorBoundary';
 
 import { setVaultToManageId, setLoadTreasuryError } from '../store';
+import { VAULT_STATES } from '../constants';
 
 const cardWidth = 360;
 const cardPadding = 16;
@@ -122,8 +123,12 @@ function VaultList() {
   const vaultsList = Object.entries(vaults ?? {});
   const vaultsToRender = vaultsList.filter(entry =>
     showClosed
-      ? ['Closed', 'Error in offer'].includes(entry[1].status)
-      : !['Closed', 'Error in offer', 'Declined'].includes(entry[1].status),
+      ? [VAULT_STATES.CLOSED, VAULT_STATES.ERROR].includes(entry[1].status)
+      : ![
+          VAULT_STATES.CLOSED,
+          VAULT_STATES.ERROR,
+          VAULT_STATES.DECLINED,
+        ].includes(entry[1].status),
   );
 
   const [redirect, setRedirect] = useState(false);
@@ -145,7 +150,7 @@ function VaultList() {
   };
 
   const showShowClosedToggle = vaultsList?.find(entry =>
-    ['Closed', 'Error in offer'].includes(entry[1].status),
+    [VAULT_STATES.CLOSED, VAULT_STATES.ERROR].includes(entry[1].status),
   );
 
   const loadTreasuryErrorAlert = (

--- a/ui/src/components/Treasury.jsx
+++ b/ui/src/components/Treasury.jsx
@@ -22,7 +22,7 @@ import { VaultSummary } from './VaultSummary';
 import ErrorBoundary from './ErrorBoundary';
 
 import { setVaultToManageId, setLoadTreasuryError } from '../store';
-import { VAULT_STATES } from '../constants';
+import { VaultStatus } from '../constants';
 
 const cardWidth = 360;
 const cardPadding = 16;
@@ -121,14 +121,12 @@ function VaultList() {
   );
 
   const vaultsList = Object.entries(vaults ?? {});
-  const vaultsToRender = vaultsList.filter(entry =>
+  const vaultsToRender = vaultsList.filter(([_key, { status }]) =>
     showClosed
-      ? [VAULT_STATES.CLOSED, VAULT_STATES.ERROR].includes(entry[1].status)
-      : ![
-          VAULT_STATES.CLOSED,
-          VAULT_STATES.ERROR,
-          VAULT_STATES.DECLINED,
-        ].includes(entry[1].status),
+      ? [VaultStatus.CLOSED, VaultStatus.ERROR].includes(status)
+      : ![VaultStatus.CLOSED, VaultStatus.ERROR, VaultStatus.DECLINED].includes(
+          status,
+        ),
   );
 
   const [redirect, setRedirect] = useState(false);
@@ -150,7 +148,7 @@ function VaultList() {
   };
 
   const showShowClosedToggle = vaultsList?.find(entry =>
-    [VAULT_STATES.CLOSED, VAULT_STATES.ERROR].includes(entry[1].status),
+    [VaultStatus.CLOSED, VaultStatus.ERROR].includes(entry[1].status),
   );
 
   const loadTreasuryErrorAlert = (

--- a/ui/src/components/VaultSummary.jsx
+++ b/ui/src/components/VaultSummary.jsx
@@ -19,6 +19,7 @@ import {
 import LoadingBlocks from './LoadingBlocks';
 import { makeDisplayFunctions } from './helpers';
 import { useApplicationContext } from '../contexts/Application';
+import { VAULT_STATES } from '../constants';
 
 const useStyles = makeStyles(theme => {
   return {
@@ -69,7 +70,7 @@ const useStyles = makeStyles(theme => {
 });
 
 const calcRatio = (priceRate, newLock, newBorrow) => {
-  const lockPrice = floorMultiplyBy(harden(newLock), priceRate);
+  const lockPrice = floorMultiplyBy(newLock, priceRate);
   return makeRatioFromAmounts(lockPrice, newBorrow);
 };
 
@@ -100,7 +101,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     status, // string
   } = vault;
 
-  const { debt = null } = debtSnapshot ?? {};
+  const debt = debtSnapshot?.debt;
 
   useEffect(() => {
     if (marketPrice && locked && debt) {
@@ -131,7 +132,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     });
   }, [vault]);
 
-  if (vault.status === 'Pending Wallet Acceptance') {
+  if (vault.status === VAULT_STATES.PENDING) {
     return (
       <div className={classes.pending}>
         <TableContainer>
@@ -158,7 +159,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === 'Error in offer') {
+  if (vault.status === VAULT_STATES.ERROR) {
     return (
       <TableContainer>
         <Table>
@@ -186,7 +187,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === 'Loading') {
+  if (vault.status === VAULT_STATES.LOADING) {
     return (
       <TableContainer>
         <Table>
@@ -210,7 +211,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === 'Closed') {
+  if (vault.status === VAULT_STATES.CLOSED) {
     return (
       <TableContainer>
         <Table>

--- a/ui/src/components/VaultSummary.jsx
+++ b/ui/src/components/VaultSummary.jsx
@@ -19,7 +19,7 @@ import {
 import LoadingBlocks from './LoadingBlocks';
 import { makeDisplayFunctions } from './helpers';
 import { useApplicationContext } from '../contexts/Application';
-import { VAULT_STATES } from '../constants';
+import { VaultStatus } from '../constants';
 
 const useStyles = makeStyles(theme => {
   return {
@@ -132,7 +132,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     });
   }, [vault]);
 
-  if (vault.status === VAULT_STATES.PENDING) {
+  if (vault.status === VaultStatus.PENDING) {
     return (
       <div className={classes.pending}>
         <TableContainer>
@@ -159,7 +159,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === VAULT_STATES.ERROR) {
+  if (vault.status === VaultStatus.ERROR) {
     return (
       <TableContainer>
         <Table>
@@ -187,7 +187,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === VAULT_STATES.LOADING) {
+  if (vault.status === VaultStatus.LOADING) {
     return (
       <TableContainer>
         <Table>
@@ -211,7 +211,7 @@ export function VaultSummary({ vault, brandToInfo, id }) {
     );
   }
 
-  if (vault.status === VAULT_STATES.CLOSED) {
+  if (vault.status === VaultStatus.CLOSED) {
     return (
       <TableContainer>
         <Table>

--- a/ui/src/components/VaultSummary.jsx
+++ b/ui/src/components/VaultSummary.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 
 import { AmountMath } from '@agoric/ertp';
-import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport';
+import {
+  makeRatioFromAmounts,
+  floorMultiplyBy,
+} from '@agoric/zoe/src/contractSupport';
 import { Nat } from '@endo/nat';
 import { E } from '@endo/eventual-send';
 import { makeStyles } from '@material-ui/core/styles';
@@ -65,14 +68,10 @@ const useStyles = makeStyles(theme => {
   };
 });
 
-const calcRatio = (priceRate, newLock, newBorrow) =>
-  makeRatioFromAmounts(
-    AmountMath.make(newLock.brand, newLock.value * priceRate.numerator.value),
-    AmountMath.make(
-      newBorrow.brand,
-      newBorrow.value * priceRate.denominator.value,
-    ),
-  );
+const calcRatio = (priceRate, newLock, newBorrow) => {
+  const lockPrice = floorMultiplyBy(harden(newLock), priceRate);
+  return makeRatioFromAmounts(lockPrice, newBorrow);
+};
 
 export function VaultSummary({ vault, brandToInfo, id }) {
   const classes = useStyles();
@@ -94,12 +93,14 @@ export function VaultSummary({ vault, brandToInfo, id }) {
   } = makeDisplayFunctions(brandToInfo);
 
   const {
-    debt, // amount
+    debtSnapshot, // amount
     interestRate, // ratio
     liquidationRatio, // ratio
     locked, // amount
     status, // string
   } = vault;
+
+  const { debt = null } = debtSnapshot ?? {};
 
   useEffect(() => {
     if (marketPrice && locked && debt) {

--- a/ui/src/components/test/Treasury.test.jsx
+++ b/ui/src/components/test/Treasury.test.jsx
@@ -33,6 +33,7 @@ beforeEach(() => {
   state.vaults = null;
   state.brandToInfo = [];
   state.treasury = null;
+  window.localStorage.setItem('showClosedVaults', 'false');
 });
 
 test('renders a message when the dapp needs approval', () => {

--- a/ui/src/components/vault/VaultCreate.js
+++ b/ui/src/components/vault/VaultCreate.js
@@ -9,7 +9,7 @@ import { useApplicationContext } from '../../contexts/Application';
 import { makeLoanOffer } from '../../contexts/makeLoanOffer';
 import VaultConfirmation from './VaultConfirmation';
 import ErrorBoundary from '../ErrorBoundary';
-import { VAULT_STATES } from '../../constants';
+import { VaultStatus } from '../../constants';
 
 function VaultCreate({
   dispatch,
@@ -56,7 +56,7 @@ function VaultCreate({
       liquidationMargin,
       locked: toLock,
       stabilityFee,
-      status: VAULT_STATES.PENDING,
+      status: VaultStatus.PENDING,
       liquidationPenalty: makeRatio(3n, toBorrow.brand),
     };
     dispatch(createVault({ id, vault }));

--- a/ui/src/components/vault/VaultCreate.js
+++ b/ui/src/components/vault/VaultCreate.js
@@ -9,6 +9,7 @@ import { useApplicationContext } from '../../contexts/Application';
 import { makeLoanOffer } from '../../contexts/makeLoanOffer';
 import VaultConfirmation from './VaultConfirmation';
 import ErrorBoundary from '../ErrorBoundary';
+import { VAULT_STATES } from '../../constants';
 
 function VaultCreate({
   dispatch,
@@ -55,7 +56,7 @@ function VaultCreate({
       liquidationMargin,
       locked: toLock,
       stabilityFee,
-      status: 'Pending Wallet Acceptance',
+      status: VAULT_STATES.PENDING,
       liquidationPenalty: makeRatio(3n, toBorrow.brand),
     };
     dispatch(createVault({ id, vault }));

--- a/ui/src/components/vault/VaultManagement/VaultManagement.jsx
+++ b/ui/src/components/vault/VaultManagement/VaultManagement.jsx
@@ -69,9 +69,6 @@ const VaultManagement = () => {
     debtSnapshot,
   } = vaultToManage;
 
-  if (!locked || !debtSnapshot) {
-    return <Redirect to="/vaults" />;
-  }
   assert(locked && debtSnapshot);
   const { debt } = debtSnapshot;
 

--- a/ui/src/components/vault/VaultManagement/VaultManagement.jsx
+++ b/ui/src/components/vault/VaultManagement/VaultManagement.jsx
@@ -142,7 +142,7 @@ const VaultManagement = () => {
   };
 
   const calcRatio = (priceRate, newLock, newBorrow) => {
-    const lockPrice = floorMultiplyBy(harden(newLock), priceRate);
+    const lockPrice = floorMultiplyBy(newLock, priceRate);
     return makeRatioFromAmounts(lockPrice, newBorrow);
   };
 

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -2,7 +2,7 @@
 export const AGORIC_LOGO_URL =
   'https://agoric.com/wp-content/themes/agoric_2021_theme/assets/img/logo.svg';
 
-export const VAULT_STATES = {
+export const VaultStatus = /** @type {const} */ ({
   PENDING: 'Pending Wallet Acceptance',
   ERROR: 'Error in Offer',
   INITIATED: 'Loan Initiated',
@@ -10,4 +10,5 @@ export const VAULT_STATES = {
   LOADING: 'Loading',
   CLOSED: 'Closed',
   DECLINED: 'Declined',
-};
+});
+/** @typedef {typeof VaultStatus[keyof typeof VaultStatus]} VaultStatus */

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -1,3 +1,13 @@
 // Agoric branded logo used for page titles and headers.
 export const AGORIC_LOGO_URL =
   'https://agoric.com/wp-content/themes/agoric_2021_theme/assets/img/logo.svg';
+
+export const VAULT_STATES = {
+  PENDING: 'Pending Wallet Acceptance',
+  ERROR: 'Error in Offer',
+  INITIATED: 'Loan Initiated',
+  LIQUIDATED: 'Liquidated',
+  LOADING: 'Loading',
+  CLOSED: 'Closed',
+  DECLINED: 'Declined',
+};

--- a/ui/src/contexts/Application.jsx
+++ b/ui/src/contexts/Application.jsx
@@ -23,6 +23,7 @@ import {
 import { updateBrandPetnames, storeAllBrandsFromTerms } from './storeBrandInfo';
 import WalletConnection from '../components/WalletConnection';
 import { getRunLoCTerms } from '../runLoCStub';
+import { VAULT_STATES } from '../constants';
 
 // eslint-disable-next-line import/no-mutable-exports
 let walletP;
@@ -55,7 +56,7 @@ function watchVault(id, dispatch, offerStatus) {
     dispatch(
       updateVault({
         id,
-        vault: { status: 'Pending Wallet Acceptance' },
+        vault: { status: VAULT_STATES.PENDING },
       }),
     );
   } else {
@@ -63,7 +64,7 @@ function watchVault(id, dispatch, offerStatus) {
       updateVault({
         id,
         vault: {
-          status: 'Loading',
+          status: VAULT_STATES.LOADING,
         },
       }),
     );
@@ -75,16 +76,19 @@ function watchVault(id, dispatch, offerStatus) {
     for await (const value of iterateNotifier(vault)) {
       console.log('======== VAULT', id, value);
       dispatch(
-        updateVault({ id, vault: { ...value, status: 'Loan Initiated' } }),
+        updateVault({
+          id,
+          vault: { ...value, status: VAULT_STATES.INITIATED },
+        }),
       );
     }
-    dispatch(updateVault({ id, vault: { status: 'Closed' } }));
-    window.localStorage.setItem(id, 'Closed');
+    dispatch(updateVault({ id, vault: { status: VAULT_STATES.CLOSED } }));
+    window.localStorage.setItem(id, VAULT_STATES.CLOSED);
   }
 
   vaultUpdater().catch(err => {
     console.error('Vault watcher exception', id, err);
-    dispatch(updateVault({ id, vault: { status: 'Error in offer', err } }));
+    dispatch(updateVault({ id, vault: { status: VAULT_STATES.ERROR, err } }));
   });
 }
 
@@ -110,16 +114,16 @@ function watchOffers(dispatch, INSTANCE_BOARD_ID) {
             dispatch(
               updateVault({
                 id,
-                vault: { status: 'Declined' },
+                vault: { status: VAULT_STATES.DECLINED },
               }),
             );
-          } else if (window.localStorage.getItem(id) === 'Closed') {
+          } else if (window.localStorage.getItem(id) === VAULT_STATES.CLOSED) {
             // We can cache closed vaults since their notifiers cannot update
             // anymore.
             dispatch(
               updateVault({
                 id,
-                vault: { status: 'Closed' },
+                vault: { status: VAULT_STATES.CLOSED },
               }),
             );
           } else if (!watchedVaults.has(id)) {

--- a/ui/src/contexts/Application.jsx
+++ b/ui/src/contexts/Application.jsx
@@ -70,8 +70,9 @@ function watchVault(id, dispatch, offerStatus) {
   }
 
   async function vaultUpdater() {
-    const uiNotifier = E(walletP).getUINotifier(id);
-    for await (const value of iterateNotifier(uiNotifier)) {
+    // TODO: Do something with asset notifier.
+    const { vault, _asset } = await E(walletP).getPublicNotifiers(id);
+    for await (const value of iterateNotifier(vault)) {
       console.log('======== VAULT', id, value);
       dispatch(
         updateVault({ id, vault: { ...value, status: 'Loan Initiated' } }),

--- a/ui/src/contexts/Application.jsx
+++ b/ui/src/contexts/Application.jsx
@@ -23,7 +23,7 @@ import {
 import { updateBrandPetnames, storeAllBrandsFromTerms } from './storeBrandInfo';
 import WalletConnection from '../components/WalletConnection';
 import { getRunLoCTerms } from '../runLoCStub';
-import { VAULT_STATES } from '../constants';
+import { VaultStatus } from '../constants';
 
 // eslint-disable-next-line import/no-mutable-exports
 let walletP;
@@ -56,7 +56,7 @@ function watchVault(id, dispatch, offerStatus) {
     dispatch(
       updateVault({
         id,
-        vault: { status: VAULT_STATES.PENDING },
+        vault: { status: VaultStatus.PENDING },
       }),
     );
   } else {
@@ -64,7 +64,7 @@ function watchVault(id, dispatch, offerStatus) {
       updateVault({
         id,
         vault: {
-          status: VAULT_STATES.LOADING,
+          status: VaultStatus.LOADING,
         },
       }),
     );
@@ -78,17 +78,17 @@ function watchVault(id, dispatch, offerStatus) {
       dispatch(
         updateVault({
           id,
-          vault: { ...value, status: VAULT_STATES.INITIATED },
+          vault: { ...value, status: VaultStatus.INITIATED },
         }),
       );
     }
-    dispatch(updateVault({ id, vault: { status: VAULT_STATES.CLOSED } }));
-    window.localStorage.setItem(id, VAULT_STATES.CLOSED);
+    dispatch(updateVault({ id, vault: { status: VaultStatus.CLOSED } }));
+    window.localStorage.setItem(id, VaultStatus.CLOSED);
   }
 
   vaultUpdater().catch(err => {
     console.error('Vault watcher exception', id, err);
-    dispatch(updateVault({ id, vault: { status: VAULT_STATES.ERROR, err } }));
+    dispatch(updateVault({ id, vault: { status: VaultStatus.ERROR, err } }));
   });
 }
 
@@ -114,18 +114,19 @@ function watchOffers(dispatch, INSTANCE_BOARD_ID) {
             dispatch(
               updateVault({
                 id,
-                vault: { status: VAULT_STATES.DECLINED },
+                vault: { status: VaultStatus.DECLINED },
               }),
             );
-          } else if (window.localStorage.getItem(id) === VAULT_STATES.CLOSED) {
+          } else if (window.localStorage.getItem(id) === VaultStatus.CLOSED) {
             // We can cache closed vaults since their notifiers cannot update
             // anymore.
             dispatch(
               updateVault({
                 id,
-                vault: { status: VAULT_STATES.CLOSED },
+                vault: { status: VaultStatus.CLOSED },
               }),
             );
+            watchedVaults.add(id);
           } else if (!watchedVaults.has(id)) {
             watchedVaults.add(id);
             watchVault(id, dispatch, status);

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -3,7 +3,7 @@
 // The code in this file requires an understanding of Autodux.
 // See: https://github.com/ericelliott/autodux
 import autodux from 'autodux';
-import { VAULT_STATES } from './constants';
+import { VaultStatus } from './constants';
 
 export const initial = {
   approved: true,
@@ -102,7 +102,7 @@ export const {
     /** @type {(state: TreasuryState, v: { id: string, vault: VaultData }) => TreasuryState} */
     updateVault: ({ vaults, ...state }, { id, vault }) => {
       const oldVaultData = vaults && vaults[id];
-      const status = vault.liquidated ? VAULT_STATES.LIQUIDATED : vault.status;
+      const status = vault.liquidated ? VaultStatus.LIQUIDATED : vault.status;
       return {
         ...state,
         vaults: { ...vaults, [id]: { ...oldVaultData, ...vault, status } },

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -3,6 +3,7 @@
 // The code in this file requires an understanding of Autodux.
 // See: https://github.com/ericelliott/autodux
 import autodux from 'autodux';
+import { VAULT_STATES } from './constants';
 
 export const initial = {
   approved: true,
@@ -101,7 +102,7 @@ export const {
     /** @type {(state: TreasuryState, v: { id: string, vault: VaultData }) => TreasuryState} */
     updateVault: ({ vaults, ...state }, { id, vault }) => {
       const oldVaultData = vaults && vaults[id];
-      const status = vault.liquidated ? 'Liquidated' : vault.status;
+      const status = vault.liquidated ? VAULT_STATES.LIQUIDATED : vault.status;
       return {
         ...state,
         vaults: { ...vaults, [id]: { ...oldVaultData, ...vault, status } },

--- a/ui/src/types/types.js
+++ b/ui/src/types/types.js
@@ -76,22 +76,19 @@
  */
 
 /**
- * @typedef {{
- *  debt?: Amount,
- *  interest?: Ratio,
- * }} DebtSnapshot
+ * @typedef  { import('@agoric/run-protocol/src/vaultFactory/vault').VaultUIState } VaultUIState
  */
 
 /**
  * @typedef {{
- *   status?: 'Pending Wallet Acceptance' | 'Error in offer'| 'Loan Initiated' | 'Liquidated' | 'Loading',
+ *   status: import('../constants').VaultStatus,
  *   liquidated?: boolean,
- *   locked?: Amount | null,
- *   collateralizationRatio?: Ratio | null,
- *   debtSnapshot?: DebtSnapshot,
- *   interestRate?:  Ratio | null,
- *   liquidationRatio?: Ratio | null,
- *   err?: Error
+ *   locked?: VaultUIState['locked'],
+ *   collateralizationRatio?: Ratio,
+ *   debtSnapshot?: VaultUIState['debtSnapshot'],
+ *   interestRate?:  VaultUIState['interestRate'],
+ *   liquidationRatio?: VaultUIState['liquidationRatio'],
+ *   err?: Error,
  * }} VaultData
  */
 
@@ -101,6 +98,6 @@
  *   treasuryAPI: unknown,
  *   runIssuer: Issuer,
  *   runBrand: Brand,
- *   priceAuthority: unknown,
+ *   priceAuthority: ERef<PriceAuthority>,
  * }} VaultState
  */

--- a/ui/src/types/types.js
+++ b/ui/src/types/types.js
@@ -84,7 +84,7 @@
 
 /**
  * @typedef {{
- *   status?: 'Pending Wallet Acceptance' | 'Error in offer'| 'Loan Initiated' | 'Liquidated',
+ *   status?: 'Pending Wallet Acceptance' | 'Error in offer'| 'Loan Initiated' | 'Liquidated' | 'Loading',
  *   liquidated?: boolean,
  *   locked?: Amount | null,
  *   collateralizationRatio?: Ratio | null,

--- a/ui/src/types/types.js
+++ b/ui/src/types/types.js
@@ -77,11 +77,18 @@
 
 /**
  * @typedef {{
+ *  debt?: Amount,
+ *  interest?: Ratio,
+ * }} DebtSnapshot
+ */
+
+/**
+ * @typedef {{
  *   status?: 'Pending Wallet Acceptance' | 'Error in offer'| 'Loan Initiated' | 'Liquidated',
  *   liquidated?: boolean,
  *   locked?: Amount | null,
  *   collateralizationRatio?: Ratio | null,
- *   debt?: Amount | null,
+ *   debtSnapshot?: DebtSnapshot,
  *   interestRate?:  Ratio | null,
  *   liquidationRatio?: Ratio | null,
  *   err?: Error

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,20 @@
   resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.16-dev-0c5d62c.0.tgz#3673e0ecc2eacd4d5bb84f6ed315af384793a862"
   integrity sha512-SYpANSBpupJZnydwDDLeXN9q+cHJboJ5L4sM71uTa+146SG2Dv7hraUTOjE4B3Ocxx/vH6qTBtT9xos6P2mvFA==
 
+"@agoric/assert@0.3.17-dev-6ca21d1.0+6ca21d1":
+  version "0.3.17-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/assert/-/assert-0.3.17-dev-6ca21d1.0.tgz#636ee6b4c1f0d6fd6fe573f7d80ff92f0ce27fa0"
+  integrity sha512-yBOUN0HaIQRp7naTOmqDQC03h01BtnwhPSd9g5qc+lvjU0OoC0km5aV7AKZBwayuiGTv0pDIupwWA5sfxNAEYg==
+
+"@agoric/babel-generator@^7.17.4", "@agoric/babel-generator@^7.17.6":
+  version "7.17.6"
+  resolved "https://registry.yarnpkg.com/@agoric/babel-generator/-/babel-generator-7.17.6.tgz#75ff4629468a481d670b4154bcfade11af6de674"
+  integrity sha512-D2wnk5fGajxMN5SCRSaA/triQGEaEX2Du0EzrRqobuD4wRXjvtF1e7jC1PPOk/RC2bZ8/0fzp0CHOiB7YLwb5w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@agoric/babel-parser@^7.6.4":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@agoric/babel-parser/-/babel-parser-7.9.4.tgz#2f9fd67f75a4a00bd1853e9d625bcc8ed479a564"
@@ -89,6 +103,21 @@
     "@agoric/store" "0.6.9-dev-0c5d62c.0+0c5d62c"
     "@endo/marshal" "^0.5.4"
 
+"@agoric/ertp@0.13.4-dev-6ca21d1.0+6ca21d1":
+  version "0.13.4-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/ertp/-/ertp-0.13.4-dev-6ca21d1.0.tgz#ef1ba983dc2373b039c958fa4c7b4a3f6f837e34"
+  integrity sha512-TI7YvJqvGhwX+TpofAGIk3sXxkFFaPWW0jOYVPxNGFw2aPJgvD12YkU1M2qasPvxgG5eKABYnPHB+jwzw2Oosw==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swingset-vat" "0.25.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vat-data" "0.1.1-dev-6ca21d1.0+6ca21d1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
+
 "@agoric/eventual-send@0.14.1-dev-0c5d62c.0+0c5d62c":
   version "0.14.1-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/eventual-send/-/eventual-send-0.14.1-dev-0c5d62c.0.tgz#ecd9ca7b615cd4629c087d39973f347c2383d542"
@@ -110,6 +139,23 @@
     "@endo/captp" "^1.10.12"
     "@endo/marshal" "^0.5.4"
 
+"@agoric/governance@0.4.4-dev-6ca21d1.0+6ca21d1":
+  version "0.4.4-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/governance/-/governance-0.4.4-dev-6ca21d1.0.tgz#4284292d90f53b8b07df3ce786cc687e67b71672"
+  integrity sha512-eYrYSHLy8mQclXGe7duJ6PgYBiW2W9M4v1TsqCO2bXJpSGDULOI/0Tqd5NTUGlFqcL7/odOafjLvSPa4EeJjaA==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/zoe" "0.21.4-dev-6ca21d1.0+6ca21d1"
+    "@endo/captp" "^2.0.3"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/far" "^0.1.9"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
+
 "@agoric/import-manager@0.2.34-dev-0c5d62c.0+0c5d62c":
   version "0.2.34-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/import-manager/-/import-manager-0.2.34-dev-0c5d62c.0.tgz#8a2c5e46a5119eaabefa1ee155f9e471008cc749"
@@ -129,6 +175,16 @@
     "@agoric/eventual-send" "0.14.1-dev-0c5d62c.0+0c5d62c"
     "@agoric/promise-kit" "0.2.30-dev-0c5d62c.0+0c5d62c"
     "@endo/marshal" "^0.5.4"
+
+"@agoric/notifier@0.3.36-dev-6ca21d1.0+6ca21d1":
+  version "0.3.36-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/notifier/-/notifier-0.3.36-dev-6ca21d1.0.tgz#5f004b69599b1377472fbbc8ca385c69c7b18782"
+  integrity sha512-aAPhL2+kJ7R7mRT+NGj2W/twiUiV0a8rgNr3DCydAvSQ48EjwYy4aC7XOi46HgmlNrZrP752nQpKrARVHPDoAA==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
 
 "@agoric/pegasus@0.5.2-dev-0c5d62c.0+0c5d62c":
   version "0.5.2-dev-0c5d62c.0"
@@ -150,6 +206,26 @@
     "@endo/captp" "^1.10.12"
     "@endo/init" "^0.5.33"
     "@endo/marshal" "^0.5.4"
+
+"@agoric/pegasus@0.6.2-dev-6ca21d1.0+6ca21d1":
+  version "0.6.2-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/pegasus/-/pegasus-0.6.2-dev-6ca21d1.0.tgz#3e6ce78fa9839a59cc3336dd50db882cb0d01f77"
+  integrity sha512-cVVXf0pw4H3qoW5gQ48myxnJzWEcq0Q6r5bt0kEqjruUGl2A8GYgTjVVajmPew4voj02nvpDJiVNMD0HXRcHCg==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swingset-vat" "0.25.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vats" "0.7.1-dev-6ca21d1.0+6ca21d1"
+    "@agoric/zoe" "0.21.4-dev-6ca21d1.0+6ca21d1"
+    "@endo/bundle-source" "^2.1.1"
+    "@endo/captp" "^2.0.3"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/init" "^0.5.37"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
 
 "@agoric/promise-kit@0.2.30-dev-0c5d62c.0+0c5d62c":
   version "0.2.30-dev-0c5d62c.0"
@@ -178,6 +254,28 @@
     "@endo/far" "^0.1.5"
     "@endo/marshal" "^0.5.4"
 
+"@agoric/run-protocol@0.8.1-dev-6ca21d1.0+6ca21d1", "@agoric/run-protocol@dev":
+  version "0.8.1-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/run-protocol/-/run-protocol-0.8.1-dev-6ca21d1.0.tgz#88f9d9033dcc27bfddddd0eee8216e7e217b694b"
+  integrity sha512-OorhwXoJmOWIaZgFzjsJb89IaKTykjrEBjMQhI4HXfoCJ7D0w/YsvOTip+I4CFKABY6CuVhoU+fp3OE2adZ67g==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/governance" "0.4.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swingset-vat" "0.25.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vat-data" "0.1.1-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vats" "0.7.1-dev-6ca21d1.0+6ca21d1"
+    "@agoric/zoe" "0.21.4-dev-6ca21d1.0+6ca21d1"
+    "@endo/bundle-source" "^2.1.1"
+    "@endo/captp" "^2.0.3"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/far" "^0.1.9"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
+
 "@agoric/same-structure@dev":
   version "0.1.30-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/same-structure/-/same-structure-0.1.30-dev-0c5d62c.0.tgz#6e061d38121af7ba8fb8ae9001ac29d54d276124"
@@ -195,10 +293,28 @@
     "@agoric/assert" "0.3.16-dev-0c5d62c.0+0c5d62c"
     "@endo/marshal" "^0.5.4"
 
+"@agoric/sharing-service@0.1.36-dev-6ca21d1.0+6ca21d1":
+  version "0.1.36-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/sharing-service/-/sharing-service-0.1.36-dev-6ca21d1.0.tgz#eb357c53b9a9a5e4fe0ee8dd8ecf85260cca6ea2"
+  integrity sha512-ymaA5jF4nqKuy5uUX+AapMtqh5WtwwAtBQ9GRL50/MMN1fHRAvFjT9QBITDd6GyCWNW5B6TY4FHPaxG8l9e1rA==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@endo/marshal" "^0.6.3"
+
 "@agoric/sparse-ints@0.1.25-dev-0c5d62c.0+0c5d62c":
   version "0.1.25-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/sparse-ints/-/sparse-ints-0.1.25-dev-0c5d62c.0.tgz#5d593a079a8ced6d7e9c84767477f7a01c145421"
   integrity sha512-/eroNlNHIho6WdLlXzXFSocU5/ZKRmecNJOszEuNw2i93tbUe1MlqZD+BU/bygHXgeeSqkRJfNkdXJKIr7L0xw==
+
+"@agoric/store@0.6.11-dev-6ca21d1.0+6ca21d1":
+  version "0.6.11-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/store/-/store-0.6.11-dev-6ca21d1.0.tgz#b9d38bfd20a6f14db74b69aa6259122d58006b64"
+  integrity sha512-MTiJz92dayxGBTynxisgVYdWSdfh+a7dGUIbvW9HjwxOGZ95ZKC0C2GGGBf8kKy32xfSi/dQOL4POxZGBozgAA==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
 
 "@agoric/store@0.6.9-dev-0c5d62c.0+0c5d62c":
   version "0.6.9-dev-0c5d62c.0"
@@ -216,6 +332,16 @@
   integrity sha512-WDMpZfl8bpTZ9+rDgvFmPSHzmZ+tUTiq1p0xXaqPuLnnaDNKplf9vWQgupohtLiripi1CnfCkqkxq1aIAMO9OA==
   dependencies:
     "@agoric/assert" "0.3.16-dev-0c5d62c.0+0c5d62c"
+    better-sqlite3 "^7.4.1"
+    node-lmdb "^0.9.5"
+    tmp "^0.2.1"
+
+"@agoric/swing-store@0.6.6-dev-6ca21d1.0+6ca21d1":
+  version "0.6.6-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/swing-store/-/swing-store-0.6.6-dev-6ca21d1.0.tgz#4ef789db979d4bd195509e8dccd04248ca2efcfa"
+  integrity sha512-K9GXp+om4vRGPksKqZEra8nASRMxQ/uEa27urfbLDB3+Vl3/xeLxbbI8wCRpH7OY5mRn6jojxA53aeQHSJKmuQ==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
     better-sqlite3 "^7.4.1"
     node-lmdb "^0.9.5"
     tmp "^0.2.1"
@@ -244,6 +370,34 @@
     node-lmdb "^0.9.5"
     semver "^6.3.0"
 
+"@agoric/swingset-vat@0.25.2-dev-6ca21d1.0+6ca21d1":
+  version "0.25.2-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/swingset-vat/-/swingset-vat-0.25.2-dev-6ca21d1.0.tgz#2dadebdbd9343d4fd95c44a2f41c51a3a6b1e1b1"
+  integrity sha512-Qmkaa2zphzyCDrvfrftmgU0ff1NkVBLMR1ejxmTSKoD+2iV5W/LGnvz1cVTUF5IGLF4BCgiX2nxVdhwyI7cOOw==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swing-store" "0.6.6-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vat-data" "0.1.1-dev-6ca21d1.0+6ca21d1"
+    "@agoric/xsnap" "0.11.3-dev-6ca21d1.0+6ca21d1"
+    "@endo/base64" "^0.2.21"
+    "@endo/bundle-source" "^2.1.1"
+    "@endo/captp" "^2.0.3"
+    "@endo/check-bundle" "^0.1.2"
+    "@endo/compartment-mapper" "^0.7.1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/import-bundle" "^0.2.41"
+    "@endo/init" "^0.5.37"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
+    "@endo/zip" "^0.2.21"
+    anylogger "^0.21.0"
+    import-meta-resolve "^1.1.1"
+    node-lmdb "^0.9.5"
+    semver "^6.3.0"
+
 "@agoric/telemetry@0.1.1-dev-0c5d62c.0+0c5d62c":
   version "0.1.1-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/telemetry/-/telemetry-0.1.1-dev-0c5d62c.0.tgz#69fb4b9b74ec3b1a85c0c5433808934ef08a800e"
@@ -264,6 +418,14 @@
     "@agoric/zoe" "0.21.2-dev-0c5d62c.0+0c5d62c"
     "@endo/init" "^0.5.33"
     clsx "^1.1.1"
+
+"@agoric/vat-data@0.1.1-dev-6ca21d1.0+6ca21d1":
+  version "0.1.1-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/vat-data/-/vat-data-0.1.1-dev-6ca21d1.0.tgz#f9befac1abeb0a6c1a02157d03c0972c51c254c7"
+  integrity sha512-V2mHUJKnfvImh1RSqK2HPdtvzX+Atvv+5VDTnFD5cM7oldgjCzK3l84gcV46Jm3PM3LI6O1O8q3d7KTn1zHQfw==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
 
 "@agoric/vats@0.5.2-dev-0c5d62c.0+0c5d62c":
   version "0.5.2-dev-0c5d62c.0"
@@ -288,6 +450,46 @@
     "@endo/import-bundle" "^0.2.37"
     "@endo/init" "^0.5.33"
     "@endo/marshal" "^0.5.4"
+
+"@agoric/vats@0.7.1-dev-6ca21d1.0+6ca21d1":
+  version "0.7.1-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/vats/-/vats-0.7.1-dev-6ca21d1.0.tgz#4f97d85a9e3bc1160f8bfaf9031c199f515189db"
+  integrity sha512-lD67+rOmRBfAwriSLj6jxr9w52+rG8+5Ai0lMfCJerGrzj4IGiLjuC7xC4trZyM9Iv6svaqij1Y7fhzYsVwwXg==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/governance" "0.4.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/pegasus" "0.6.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/run-protocol" "0.8.1-dev-6ca21d1.0+6ca21d1"
+    "@agoric/sharing-service" "0.1.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swingset-vat" "0.25.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/wallet-backend" "0.10.10-dev-6ca21d1.0+6ca21d1"
+    "@agoric/zoe" "0.21.4-dev-6ca21d1.0+6ca21d1"
+    "@endo/far" "^0.1.9"
+    "@endo/import-bundle" "^0.2.41"
+    "@endo/init" "^0.5.37"
+    "@endo/marshal" "^0.6.3"
+    "@endo/nat" "^4.1.8"
+    "@endo/promise-kit" "^0.2.37"
+
+"@agoric/wallet-backend@0.10.10-dev-6ca21d1.0+6ca21d1":
+  version "0.10.10-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/wallet-backend/-/wallet-backend-0.10.10-dev-6ca21d1.0.tgz#0230de383895f1ab252c5a3f90765280f28f0c6b"
+  integrity sha512-Ez0xZjWR4qgTE/LtBzEs2BwYp7zHX4ajOSwFky3i7xCRJEYYGT6yj2T+iUQIoczZsQKXdq2VaIm+H89IHa1HBw==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/zoe" "0.21.4-dev-6ca21d1.0+6ca21d1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
+    import-meta-resolve "^1.1.1"
 
 "@agoric/wallet-backend@0.10.8-dev-0c5d62c.0+0c5d62c":
   version "0.10.8-dev-0c5d62c.0"
@@ -336,6 +538,20 @@
     "@endo/netstring" "^0.3.3"
     glob "^7.1.6"
 
+"@agoric/xsnap@0.11.3-dev-6ca21d1.0+6ca21d1":
+  version "0.11.3-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/xsnap/-/xsnap-0.11.3-dev-6ca21d1.0.tgz#311f95df41a428e29ff218f8273969e917f0b50e"
+  integrity sha512-GqjG5KBkedbhn+oKvBjP5lkp8epn/8xNuU2c1b45p0dcOIFP5mkALSQYQ4AI0lQVAvR8+FHs3ZQ2m8O7QdfoNg==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@endo/bundle-source" "^2.1.1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/init" "^0.5.37"
+    "@endo/netstring" "^0.3.7"
+    "@endo/stream" "^0.3.6"
+    "@endo/stream-node" "^0.2.7"
+    glob "^7.1.6"
+
 "@agoric/zoe@0.21.2-dev-0c5d62c.0+0c5d62c", "@agoric/zoe@dev":
   version "0.21.2-dev-0c5d62c.0"
   resolved "https://registry.yarnpkg.com/@agoric/zoe/-/zoe-0.21.2-dev-0c5d62c.0.tgz#e2a5bd657d65e32139b862a646c1cc8cd92b28c9"
@@ -354,6 +570,25 @@
     "@endo/far" "^0.1.5"
     "@endo/import-bundle" "^0.2.37"
     "@endo/marshal" "^0.5.4"
+
+"@agoric/zoe@0.21.4-dev-6ca21d1.0+6ca21d1":
+  version "0.21.4-dev-6ca21d1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/zoe/-/zoe-0.21.4-dev-6ca21d1.0.tgz#c4d73349d47bdb6961a2d97bffa32dd3644dd5b7"
+  integrity sha512-M9NbyAmwdxJBgnj6/hponwfE1QiUYiJBnmP9Jde3RRpia3DIPuzKKxvsKiQ/12K72vCmTDro2B9lwpSHUdczGg==
+  dependencies:
+    "@agoric/assert" "0.3.17-dev-6ca21d1.0+6ca21d1"
+    "@agoric/ertp" "0.13.4-dev-6ca21d1.0+6ca21d1"
+    "@agoric/nat" "^4.1.0"
+    "@agoric/notifier" "0.3.36-dev-6ca21d1.0+6ca21d1"
+    "@agoric/store" "0.6.11-dev-6ca21d1.0+6ca21d1"
+    "@agoric/swingset-vat" "0.25.2-dev-6ca21d1.0+6ca21d1"
+    "@agoric/vat-data" "0.1.1-dev-6ca21d1.0+6ca21d1"
+    "@endo/bundle-source" "^2.1.1"
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/far" "^0.1.9"
+    "@endo/import-bundle" "^0.2.41"
+    "@endo/marshal" "^0.6.3"
+    "@endo/promise-kit" "^0.2.37"
 
 "@babel/code-frame@7.10.4":
   version "7.10.4"
@@ -457,6 +692,15 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e"
   integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.17.3":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
   dependencies:
     "@babel/types" "^7.17.0"
     jsesc "^2.5.1"
@@ -780,6 +1024,11 @@
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
+
+"@babel/parser@^7.17.3":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
+  integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1671,6 +1920,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.13.12", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.13.12"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.12.tgz#edbf99208ef48852acdff1c8a681a1e4ade580cd"
@@ -1737,6 +2002,11 @@
   resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.17.tgz#0e2c960a9622d2fe2b616be7a8a7c8032c3737c7"
   integrity sha512-L7Pug/WdmsX6FERJ/harLywE+HPmjcE79xaHEmKToF3r0gXi+6yefk5rdAedX3q6lvBAsvuCb/07In4TU1oBrw==
 
+"@endo/base64@^0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/base64/-/base64-0.2.21.tgz#e58fc38891fda25d57f1ed90274210c8781b2f22"
+  integrity sha512-Q7L3Ns1xoWma0qisXPUukuS/imugvE17HrwrXypfQlx5k0nh9zrhfboVs59EWfYtBllF27ZmxLZW2C88IUreFQ==
+
 "@endo/bundle-source@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@endo/bundle-source/-/bundle-source-2.0.5.tgz#5dc43ab079145328efe82b43bbb25086ba8181a2"
@@ -1754,6 +2024,22 @@
     rollup "^2.47.0"
     source-map "^0.7.3"
 
+"@endo/bundle-source@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@endo/bundle-source/-/bundle-source-2.1.1.tgz#87ac2a90fea941cf253f409a06f7db9bf032f0bf"
+  integrity sha512-2XI9j7njyxlYsbECBYlN3DPNPrIBlmbtikXB7qp1XuRYBwyiXC2D3ch0nbO+swBCJZCueBPcnrEwrcvn3BQaIw==
+  dependencies:
+    "@agoric/babel-generator" "^7.17.4"
+    "@babel/parser" "^7.17.3"
+    "@babel/traverse" "^7.17.3"
+    "@endo/base64" "^0.2.21"
+    "@endo/compartment-mapper" "^0.7.1"
+    "@rollup/plugin-commonjs" "^19.0.0"
+    "@rollup/plugin-node-resolve" "^13.0.0"
+    acorn "^8.2.4"
+    rollup "^2.47.0"
+    source-map "^0.7.3"
+
 "@endo/captp@^1.10.12":
   version "1.10.12"
   resolved "https://registry.yarnpkg.com/@endo/captp/-/captp-1.10.12.tgz#69ce23a49ecfdf0bad84f931a55df797d2cfd0ed"
@@ -1764,10 +2050,33 @@
     "@endo/nat" "^4.1.4"
     "@endo/promise-kit" "^0.2.33"
 
+"@endo/captp@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@endo/captp/-/captp-2.0.3.tgz#780d0439834fe4f5d281b07774ecd2e7ea9ab13c"
+  integrity sha512-NNIm2UAJB3sTnjl1W2WdhFAMrG8w2/LdOYAAsfixcwu7CH+6xLyUMVq3ZHUtjs9Wlc299UPW7Is+13Bh5VuBIA==
+  dependencies:
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+    "@endo/nat" "^4.1.8"
+    "@endo/promise-kit" "^0.2.37"
+
+"@endo/check-bundle@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@endo/check-bundle/-/check-bundle-0.1.2.tgz#0cdaf1436f858d08ea597081755602df2cdacfdc"
+  integrity sha512-vj44CM52WsXN+YryrCBRfC1V2jzQVgl27rT6hjUg6qR0/xJ7Py/Zgi9eF3kO3Vntx+/RIOa73QYBIfzxevY5MA==
+  dependencies:
+    "@endo/base64" "^0.2.21"
+    "@endo/compartment-mapper" "^0.7.1"
+
 "@endo/cjs-module-analyzer@^0.2.17":
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.17.tgz#002742b7a1c44eab92aaf91ed00665666c20b7f0"
   integrity sha512-W+5VcO6LHA+7lwqezX81tNA7FTP568ljZtc3OUr9ZGPzgIdxvn12GjLzqIYn/mJe/qxlVVg2VWMhCkSa4Kagog==
+
+"@endo/cjs-module-analyzer@^0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/cjs-module-analyzer/-/cjs-module-analyzer-0.2.21.tgz#e6b6f65d9378d1e56a62caa69948f9e2e442dd17"
+  integrity sha512-nmRVyuqVWTVzewn/4Iy28XGPXcxwdR0475V8E0151Iy221Xyi4q+EcsB4lLbu8dIimkps8pR1eoY4oCWsedbTw==
 
 "@endo/compartment-mapper@^0.6.5":
   version "0.6.5"
@@ -1778,6 +2087,16 @@
     "@endo/static-module-record" "^0.6.12"
     "@endo/zip" "^0.2.17"
     ses "^0.15.7"
+
+"@endo/compartment-mapper@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@endo/compartment-mapper/-/compartment-mapper-0.7.1.tgz#f740db7557727e0c4bee6eb5b96d7489080e84c0"
+  integrity sha512-Oj3gvvqkROUnD3Ckzw10OXY7kFTFA7sAVgE7E7HhURq/CBe1A0RD11iOQRhAlPMEXSk0dUkpTxnpXkxYwlIncQ==
+  dependencies:
+    "@endo/cjs-module-analyzer" "^0.2.21"
+    "@endo/static-module-record" "^0.7.0"
+    "@endo/zip" "^0.2.21"
+    ses "^0.15.11"
 
 "@endo/eslint-plugin@^0.3.20":
   version "0.3.20"
@@ -1791,6 +2110,11 @@
   resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.14.4.tgz#40f2c7fd64d66e1ed5eaf15a90d6d689af13eb36"
   integrity sha512-1MSnq7bcCustCIKB7TJ1cfCg7A0W/LmX9bxhIV1syG7TO3mgV1DX7YceU0Ek+JDlqR3x9cM12WeaXfM+1ggfKg==
 
+"@endo/eventual-send@^0.14.8":
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/@endo/eventual-send/-/eventual-send-0.14.8.tgz#0d95b5cd7e420219cdd84c43683bfbd0b6cd2ff6"
+  integrity sha512-JIbzzIk1/Z+44O7+IuF5HfMzGu1txOvW5IJKu91syk//MIWU1+XQyPhwQKuWiZ2KX+ADdSPyNZTZjAN2IAE8gQ==
+
 "@endo/far@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@endo/far/-/far-0.1.5.tgz#af2640dffba5cbb326af8ccf9c42831fa9a175f8"
@@ -1799,6 +2123,14 @@
     "@endo/eventual-send" "^0.14.4"
     "@endo/marshal" "^0.5.4"
 
+"@endo/far@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@endo/far/-/far-0.1.9.tgz#284986d2d67603959b2e480ee84ebe20c8cef765"
+  integrity sha512-VMotZgQ6RsETRW+PFnYr1UXxFr85yve8Vms3HkgcSSyWM8K2y4KIoVV/exOyAEXl+pzwPWYztWs/iOrTgrj1jQ==
+  dependencies:
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/marshal" "^0.6.3"
+
 "@endo/import-bundle@^0.2.37":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/@endo/import-bundle/-/import-bundle-0.2.37.tgz#6d09d75a8ffeee6645968905b5858a32ca7606f1"
@@ -1806,6 +2138,14 @@
   dependencies:
     "@endo/base64" "^0.2.17"
     "@endo/compartment-mapper" "^0.6.5"
+
+"@endo/import-bundle@^0.2.41":
+  version "0.2.41"
+  resolved "https://registry.yarnpkg.com/@endo/import-bundle/-/import-bundle-0.2.41.tgz#6f097fbfeacd2f4c06026c0e80f1acbbec0617dd"
+  integrity sha512-XGbRCNZACJ9FPTpJ3NiLeO7/ApiWYvAJJXFYMidqkP9cRLCBd4AswwySw1/GJ6413dm6TQjUUVEomDTJKfyjog==
+  dependencies:
+    "@endo/base64" "^0.2.21"
+    "@endo/compartment-mapper" "^0.7.1"
 
 "@endo/init@^0.5.33":
   version "0.5.33"
@@ -1816,12 +2156,27 @@
     "@endo/eventual-send" "^0.14.4"
     "@endo/lockdown" "^0.1.5"
 
+"@endo/init@^0.5.37":
+  version "0.5.37"
+  resolved "https://registry.yarnpkg.com/@endo/init/-/init-0.5.37.tgz#1d49b816baf61a41f2e58bde7f12a5f387f5d865"
+  integrity sha512-iPj2tcyrT0AZ+n2xjL7VUzG12y9aoLD+2fqa78CyLhkWosZkVnRapmQY+09/Cffnrwpm9VMiYjWcmaHowx42ZQ==
+  dependencies:
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/lockdown" "^0.1.9"
+
 "@endo/lockdown@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-0.1.5.tgz#5fdc095eb36a54590ceaeea742e91872a5293ffa"
   integrity sha512-RoH9O5QSVclDhSXxzmSYtYp/e6+BK0JUiLDPohwCW4h8wmaT6nV2chYAdwFzeGTtidnKpW/KvakvU7xceveHFg==
   dependencies:
     ses "^0.15.7"
+
+"@endo/lockdown@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@endo/lockdown/-/lockdown-0.1.9.tgz#b6c6caf1584340e130891e7005c5693e350d1084"
+  integrity sha512-s8mUfN7JzmDCbfAv73CZ6PD5h/9spnd7XvJEc9t7MhepkOIE8DP80xCTQuAwwKddUwPnSZFuGwJlflI+dP/6XA==
+  dependencies:
+    ses "^0.15.11"
 
 "@endo/marshal@^0.5.4":
   version "0.5.4"
@@ -1832,10 +2187,24 @@
     "@endo/nat" "^4.1.4"
     "@endo/promise-kit" "^0.2.33"
 
+"@endo/marshal@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@endo/marshal/-/marshal-0.6.3.tgz#9a22b77acb3371f8fb7f33958c7781c792617e9b"
+  integrity sha512-3TxX93F/hIWGU4h+dR/I5dskH7iDhMhRFfWIrmGj8yMMq6rW9CtgdOy59GfaHBJ1YB70ZH4ULwb1Iir5Z2EcLw==
+  dependencies:
+    "@endo/eventual-send" "^0.14.8"
+    "@endo/nat" "^4.1.8"
+    "@endo/promise-kit" "^0.2.37"
+
 "@endo/nat@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.4.tgz#7e9c45817b6ddb0332a115600b6e52d500efe9c7"
   integrity sha512-HfgDO3JJNKxE597v8dg0o2wVYCSmfVVF2dhza/i+j8o28gUyxZxrRlxpDWaCT44o3XpIQSepfePrqjyLGkfEcQ==
+
+"@endo/nat@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@endo/nat/-/nat-4.1.8.tgz#2c761c64f124cb610a63bded0c78a306678d6304"
+  integrity sha512-KwNkmw2tS8rDs0V3Q/cgje6JNg2AarSjFimT/hchcxz4BMBHS5mI486/W9QC3yQcxkidqX7GX3sYcD18xu5tBA==
 
 "@endo/netstring@^0.3.3":
   version "0.3.3"
@@ -1846,12 +2215,28 @@
     "@endo/stream" "^0.3.2"
     ses "^0.15.7"
 
+"@endo/netstring@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@endo/netstring/-/netstring-0.3.7.tgz#308d7d87c18844ac9b06543174cde5d125f56fd2"
+  integrity sha512-6nJ0eGN/fc+xK5jbr3032KAm2EzPRBEaApSvvu8xMHxn3p47pciTRXS+Amb3n8FI/1EhwaYe9Lue06ynAOPPew==
+  dependencies:
+    "@endo/init" "^0.5.37"
+    "@endo/stream" "^0.3.6"
+    ses "^0.15.11"
+
 "@endo/promise-kit@^0.2.33":
   version "0.2.33"
   resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.33.tgz#dd5f8d810fef6e1370ff7dfe2d95d884961840c5"
   integrity sha512-Bxt3jRB9iN7WOwiVxV2FmfBX2BfK3ffkcEhsxhnMBS8PEqVJ6M/Y+K2nV/b8v18/N7U5RA8UHY6IdRxyKjQ5Jw==
   dependencies:
     ses "^0.15.7"
+
+"@endo/promise-kit@^0.2.37":
+  version "0.2.37"
+  resolved "https://registry.yarnpkg.com/@endo/promise-kit/-/promise-kit-0.2.37.tgz#ef1506a953bbbb02793a33c7f22a6ac07783bea6"
+  integrity sha512-e8jbKRF4nPEvOq1zg/pFcO/wy7/oNdKYBdvC2DPT7WY2Q80BNQVFk9HpLC1WPn9JC+SHJBrXA8gciJCcC4emEQ==
+  dependencies:
+    ses "^0.15.11"
 
 "@endo/static-module-record@^0.6.12":
   version "0.6.12"
@@ -1861,6 +2246,26 @@
     "@agoric/babel-standalone" "^7.14.3"
     ses "^0.15.7"
 
+"@endo/static-module-record@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@endo/static-module-record/-/static-module-record-0.7.0.tgz#90ad6a85fcd8ab20c1ccb70cece5ea6f7120108a"
+  integrity sha512-A8X7Sdzy4MlJ3IJh9MM63ZKcESlP65rbYyjPNvoB5ja6IJmYF73ktGWywe5OoJZU8N7VJkgmgypby5kSxZs0uA==
+  dependencies:
+    "@agoric/babel-generator" "^7.17.6"
+    "@babel/parser" "^7.17.3"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    ses "^0.15.11"
+
+"@endo/stream-node@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@endo/stream-node/-/stream-node-0.2.7.tgz#58a500917b2af1307feda2d6fe2acb4ab90d0d26"
+  integrity sha512-UPv/QquNngWkWTCV9eQVsXfX5yn0Y+utVURISAdoDFj3Mwg4+ZYI04Qi2hAr02emJSWbxgSy9V9ZkLpnmhIgWg==
+  dependencies:
+    "@endo/init" "^0.5.37"
+    "@endo/stream" "^0.3.6"
+    ses "^0.15.11"
+
 "@endo/stream@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@endo/stream/-/stream-0.3.2.tgz#945f5b65f3835c85a7bb7cb35b1f5465243501bc"
@@ -1869,10 +2274,23 @@
     "@endo/eventual-send" "^0.14.4"
     ses "^0.15.7"
 
+"@endo/stream@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@endo/stream/-/stream-0.3.6.tgz#2fd6dd094e6a1ce928e5b25a1c11ea5154244640"
+  integrity sha512-h5Pr1V4eU6OcVPKR6SXCk7hf/ObwwHHZGBlPAGy205S+x6q1OKeexVbuMjFmsHg35+1ISfDiVSKH+f/ojgvIRw==
+  dependencies:
+    "@endo/eventual-send" "^0.14.8"
+    ses "^0.15.11"
+
 "@endo/zip@^0.2.17":
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.17.tgz#e63e3c76d25874eda24e67f40de3db451acc32c5"
   integrity sha512-OMJVC4D+krRaC06myMaNgHSRdPdYI7eA3RMeYFeGsHdfnhheWNnwnn+bJAFhgba7JCBP+lEk7i134E0EkznE4w==
+
+"@endo/zip@^0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@endo/zip/-/zip-0.2.21.tgz#98ac48439ebb8bb146b7c4488633d975a42fda2d"
+  integrity sha512-YtvksxnEAQjh+7IrwZS87n5oNiY5tv2W9W56AOCBAazlG+yPmwITVm8zQYuXlc3P1Nl2BqKzC4Xw4SfbbCtzzw==
 
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
@@ -15313,6 +15731,11 @@ serve-static@1.14.1:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+ses@^0.15.11:
+  version "0.15.11"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.15.11.tgz#851cb6a20d8967537075d25bb0185051c28c23db"
+  integrity sha512-lQg6q8/PVf+n18EjP+5Uv1tN9oVQ3br5QxJzPXoAVQleSYnlf20JY9coe7n1B9A6CtIKIHyr6m/TfskcRCufgA==
 
 ses@^0.15.7:
   version "0.15.7"


### PR DESCRIPTION
fixes: https://github.com/Agoric/agoric-sdk/issues/4882

A few other fixes included:
- Only show errored and "closed" vaults when "show closed vaults" is checked, it used to show all vaults
- Show the "show closed vaults" checkbox if there's an errored vault but no "closed" vaults. It used to only let you see errored vaults if there was also at least one "closed" vault.
- Fix the collateralization ratio calculation in the vault summary cards & vault management page, it broke when using denoms other than BLD and RUN (different decimal places).

