### PR TITLE
fix: suppress unhandled rejection overlays in dev mode

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -22,6 +22,11 @@
       });
 
       console.log('lockdown done.');
+
+      // Prevent React Dev from throwing up error overlays on unhandled rejections.
+      if ('%NODE_ENV%' !== 'production') {
+        window.addEventListener('unhandledrejection', ev => ev.stopImmediatePropagation());
+      }
     </script>
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
This change needs to be applied to all our React dapps, or else you'll get nasty error overlays whenever the bridge connection is reset.
